### PR TITLE
Add legacy providerconfig

### DIFF
--- a/providerconfig.yaml
+++ b/providerconfig.yaml
@@ -4,7 +4,6 @@ apiVersion: aws.upbound.io/v1beta1
 kind: ProviderConfig
 metadata:
   name: default
-  namespace: ns-ref-test
 spec:
   credentials:
     source: Secret


### PR DESCRIPTION
Add legacy ProviderConfig, after this PR the repo will include:

- ClusterProviderConfig
- namespaced ProviderConfig
- legacy cluster ProviderConfig

This allows the legacy resources to be provisioned successfully.