### PR TITLE
Update for mrap and 2.0.0 provider

### DIFF
--- a/ManagedResourceActivationPolicy.yaml
+++ b/ManagedResourceActivationPolicy.yaml
@@ -1,0 +1,22 @@
+apiVersion: apiextensions.crossplane.io/v1alpha1
+kind: ManagedResourceActivationPolicy
+metadata:
+  name: aws-resources
+spec:
+  activate:
+  # Required Resources
+  - clusterproviderconfigs.aws.m.upbound.io
+  - providerconfigs.aws.m.upbound.io
+  - providerconfigs.aws.upbound.io
+  - providerconfigusages.aws.m.upbound.io
+  - providerconfigusages.aws.upbound.io
+  # Namespaced Resources
+  - buckets.s3.aws.m.upbound.io 
+  - bucketpublicaccessblocks.s3.aws.m.upbound.io
+  - bucketownershipcontrols.s3.aws.m.upbound.io 
+  - bucketacls.s3.aws.m.upbound.io
+  # Cluster Scoped
+  - buckets.s3.aws.upbound.io 
+  - bucketpublicaccessblocks.s3.aws.upbound.io
+  - bucketownershipcontrols.s3.aws.upbound.io 
+  - bucketacls.s3.aws.upbound.io

--- a/provider.yaml
+++ b/provider.yaml
@@ -1,13 +1,20 @@
 apiVersion: pkg.crossplane.io/v1
 kind: Provider
 metadata:
-  name: provider-aws-s3
+  name: crossplane-contrib-provider-family-aws
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/provider-aws-s3:v2.0.0
+  package: xpkg.crossplane.io/crossplane-contrib/provider-family-aws:v2.0.0
 ---
 apiVersion: pkg.crossplane.io/v1
 kind: Provider
 metadata:
-  name: provider-aws-ec2
+  name: crossplane-contrib-provider-aws-s3
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/provider-aws-ec2:v2.0.0
+  package: xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v2.0.0
+---
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: crossplane-contrib-provider-aws-ec2
+spec:
+  package: xpkg.crossplane.io/crossplane-contrib/provider-aws-ec2:v2.0.0

--- a/provider.yaml
+++ b/provider.yaml
@@ -3,11 +3,11 @@ kind: Provider
 metadata:
   name: provider-aws-s3
 spec:
-  package: xpkg.upbound.io/upbound-release-candidates/provider-aws-s3:v2.0.0-devrc.1
+  package: xpkg.upbound.io/crossplane-contrib/provider-aws-s3:v2.0.0
 ---
 apiVersion: pkg.crossplane.io/v1
 kind: Provider
 metadata:
   name: provider-aws-ec2
 spec:
-  package: xpkg.upbound.io/upbound-release-candidates/provider-aws-ec2:v2.0.0-devrc.1
+  package: xpkg.upbound.io/crossplane-contrib/provider-aws-ec2:v2.0.0

--- a/provider.yaml
+++ b/provider.yaml
@@ -1,13 +1,6 @@
 apiVersion: pkg.crossplane.io/v1
 kind: Provider
 metadata:
-  name: crossplane-contrib-provider-family-aws
-spec:
-  package: xpkg.crossplane.io/crossplane-contrib/provider-family-aws:v2.0.0
----
-apiVersion: pkg.crossplane.io/v1
-kind: Provider
-metadata:
   name: crossplane-contrib-provider-aws-s3
 spec:
   package: xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v2.0.0


### PR DESCRIPTION
- Add ManagedResourceActivationPolicy
- Update providers to crossplane-contrib v2.0.0

Validated against Crossplane 2.0.1 with a MRAP

```shell
task v2-managed-resources:validate-all 
task: [v2-managed-resources:validate-s3-bucket] kubectl wait -n ns-ref-test --for=condition=Ready bucket.s3.aws.m.upbound.io -l demo.crossplane.io/scenario=namespaced-refs-bucket --timeout=600s
bucket.s3.aws.m.upbound.io/crossplane-bucket-d827s condition met
task: [v2-managed-resources:validate-s3-bucket] kubectl wait --for=condition=Ready -f demo-upjet-namespaced-refs/managed-resources/bucket-ownership-controls.yaml -f demo-upjet-namespaced-refs/managed-resources/bucket-public-access-block.yaml  --timeout=600s
bucketownershipcontrols.s3.aws.m.upbound.io/crossplane-bucket-ownership-controls condition met
bucketpublicaccessblock.s3.aws.m.upbound.io/crossplane-bucket-public-access-block condition met
task: [v2-managed-resources:validate-s3-bucket] kubectl wait --for=condition=Ready -f demo-upjet-namespaced-refs/managed-resources/bucket-acl.yaml --timeout=600s
bucketacl.s3.aws.m.upbound.io/crossplane-bucket-acl condition met
task: [v2-managed-resources:validate-composite] kubectl wait --for=condition=Ready  -f demo-upjet-namespaced-refs/composition/xr.yaml --timeout=600s
privatebucket.demo.crossplane.io/private-bucket condition met
task: [v2-managed-resources:validate-legacy-s3-bucket] kubectl wait -n ns-ref-test --for=condition=Ready bucket.s3.aws.upbound.io -l demo.crossplane.io/scenario=legacy-refs-bucket --timeout=600s
bucket.s3.aws.upbound.io/crossplane-bucket-45rmp condition met
bucket.s3.aws.upbound.io/crossplane-bucket-xjrsk condition met
task: [v2-managed-resources:validate-legacy-s3-bucket] kubectl wait --for=condition=Ready -f demo-upjet-namespaced-refs/legacy/bucket-ownership-controls.yaml -f demo-upjet-namespaced-refs/legacy/bucket-public-access-block.yaml  --timeout=600s
bucketownershipcontrols.s3.aws.upbound.io/crossplane-bucket-ownership-controls-legacy condition met
bucketpublicaccessblock.s3.aws.upbound.io/crossplane-bucket-public-access-block-legacy condition met
task: [v2-managed-resources:validate-legacy-s3-bucket] kubectl wait --for=condition=Ready -f demo-upjet-namespaced-refs/legacy/bucket-acl.yaml --timeout=600s
bucketacl.s3.aws.upbound.io/crossplane-bucket-acl-legacy condition met
```